### PR TITLE
ranked issue 'unable to get ranked' fixed

### DIFF
--- a/__helpers/leaderboards.js
+++ b/__helpers/leaderboards.js
@@ -4,34 +4,30 @@ const { endpoint } = require('../config.json');
 
 module.exports = (type) => {
 	return new Promise( (resolve, reject) => {
-		try {
-			if(type.toLowerCase() !== 'statistics')
-				return reject(new Error('Invalid type. Must be either statistics'))
+		if(type.toLowerCase() !== 'statistics')
+			return reject(new Error('Invalid type. Must be either statistics'))
 
-			switch (type.toLowerCase) {
-				default:
-					const params = {
-						modeId: 1,
-						filter: 'highestWPM',
-						startNum: 0,
-						limit: 10
-					}
-					const queryString = new URLSearchParams(params)
-					console.log(`GET ${endpoint}/leaderboards/${type}?${queryString}`.yellow)
-					fetch(`${endpoint}/leaderboards/${type}?${queryString}`)
-						.then(res => res.json())
-						.then( (data) => {
-							if(!data)
-								return reject(new Error('An error has occurred during search.'))
-							if(data && data.error)
-								return reject(new Error(data.error))
-							if(data)
-								return resolve(data)
-						})
-					break;
-			}
- 		} catch (err) {
-			return reject(err.message)
+		switch (type.toLowerCase) {
+			default:
+				const params = {
+					modeId: 1,
+					filter: 'highestWPM',
+					startNum: 0,
+					limit: 10
+				}
+				const queryString = new URLSearchParams(params)
+				console.log(`GET ${endpoint}/leaderboards/${type}?${queryString}`.yellow)
+				fetch(`${endpoint}/leaderboards/${type}?${queryString}`)
+					.then(res => res.json())
+					.then( (data) => {
+						if(!data)
+							return reject(new Error('An error has occurred during search.'))
+						if(data && data.error)
+							return reject(new Error(data.error))
+						if(data)
+							return resolve(data)
+					})
+				break;
 		}
 	})
 }

--- a/__helpers/player.js
+++ b/__helpers/player.js
@@ -2,53 +2,68 @@ const fetch = require('node-fetch');
 const { endpoint } = require('../config.json');
 const colors = require('colors');
 
+const rankedJsonObject = {
+	locale: 'en',
+	seasonId: 0,
+	modeId: 1,
+	rating: 0,
+	deviation: 0,
+	matchesWon: 0,
+	matchesLost: 0,
+	matchesQuit: 0,
+	created: 0,
+	Rank: { SR: 0, Games: 0, Rank: 'Unranked' }
+}
+
 module.exports = (type, option, value) => {
 	return new Promise( (resolve, reject) => {
-		try {
-			if(type.toLowerCase() !== 'ranked' && type.toLowerCase() !== 'info' && type.toLowerCase() !== 'statistics')
-				return reject(new Error('Invalid type. Must be either ranked or info or statistics.'))
+		if(type.toLowerCase() !== 'ranked' && type.toLowerCase() !== 'info' && type.toLowerCase() !== 'statistics')
+			return reject(new Error('Invalid type. Must be either ranked or info or statistics.'))
 
-			switch (option.toLowerCase()) {
-				case 'discord' : 
-					const paramsDiscord = {
-						playerId: value.toString(),
-						worldId: 0
-					}
-					const discordQueryString = new URLSearchParams(paramsDiscord)
-					console.log(`GET ${endpoint}/player/${type}?${discordQueryString}`.yellow)
-					fetch(`${endpoint}/player/${type}?${discordQueryString}`)
-						.then(res => res.json())
-						.then( (data) => {
-							if(!data)
-								return reject(new Error('An error has occurred during search.'))
-							if(data && data.error)
-								return reject(new Error(data.error))
-							if(data)
-								return resolve(data)
-						})
-					break;
-				default : 
-					if (!value.includes('-'))
-						return reject(new Error('Improperly formatted username. (ie: GNiK-8712)'))
-					const paramsDefault = {
-						name: value.toString(),
-						worldId: 0
-					}
-					const defaultQueryString = new URLSearchParams(paramsDefault)
-					console.log(`GET ${endpoint}/player/${type}?${defaultQueryString}`.yellow)
-					fetch(`${endpoint}/player/${type}?${defaultQueryString}`)
-						.then(res => res.json())
-						.then( (data) => {
-							if(!data)
-								return reject(new Error('An error has occurred during search.'))
-							if(data && data.error)
-								return reject(new Error(data.error))
-							if(data)
-								return resolve(data)
-						})
-			}
- 		} catch (err) {
-			return reject(err.message)
+		switch (option.toLowerCase()) {
+			case 'discord' : 
+				const paramsDiscord = {
+					playerId: value.toString(),
+					worldId: 0
+				}
+				const discordQueryString = new URLSearchParams(paramsDiscord)
+				console.log(`GET ${endpoint}/player/${type}?${discordQueryString}`.yellow)
+				fetch(`${endpoint}/player/${type}?${discordQueryString}`)
+					.then(res => res.json())
+					.then( (data) => {
+						if(!data)
+							return reject(new Error('An error has occurred during search.'))
+						console.log(data)
+						if(data && data.error && data.error.toLowerCase().includes('unable to get ranked') && type.toLowerCase() === 'ranked')
+							return resolve(rankedJsonObject)
+						if(data && data.error)
+							return reject(new Error(data.error))
+						if(data)
+							return resolve(data)
+					})
+				break;
+			default : 
+				if (!value.includes('-'))
+					return reject(new Error('Improperly formatted username. (ie: GNiK-8712)'))
+				const paramsDefault = {
+					name: value.toString(),
+					worldId: 0
+				}
+				const defaultQueryString = new URLSearchParams(paramsDefault)
+				console.log(`GET ${endpoint}/player/${type}?${defaultQueryString}`.yellow)
+				fetch(`${endpoint}/player/${type}?${defaultQueryString}`)
+					.then(res => res.json())
+					.then( (data) => {
+						if(!data)
+							return reject(new Error('An error has occurred during search.'))
+						console.log(data)
+						if(data && data.error && data.error.toLowerCase().includes('unable to get ranked') && type.toLowerCase() === 'ranked')
+							return resolve(rankedJsonObject)
+						if(data && data.error)
+							return reject(new Error(data.error))
+						if(data)
+							return resolve(data)
+					})
 		}
 	})
 }

--- a/commands/stats/user.js
+++ b/commands/stats/user.js
@@ -11,8 +11,10 @@ module.exports = {
             if(!args[0])
                 return message.channel.send("You must supply a user to search!");
 
-            const data = await player('info', 'user', args[0])
-            const ranked = await player('ranked', 'user', args[0])
+            const playerUsername = args[0].trim()
+
+            const data = await player('info', 'user', playerUsername)
+            const ranked = await player('ranked', 'discord', data.playerId)
             const stats = await player('statistics', 'discord', data.playerId)
 
             const userEmbed = new MessageEmbed()


### PR DESCRIPTION
Fixed the issue where bot crashes when there API ranked endpoint returns `{ error: 'Unable to get ranked!' }`.
Now it displays user-data of ranked and unranked players.